### PR TITLE
Add base config for SBT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,6 @@ project/plugins/project/
 .history
 .cache
 .lib/
+.bsp
 
+.sbt_metadata

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,6 @@
+# Matches the version here
+# https://github.com/wellcomecollection/dockerfiles/blob/master/scalafmt/Dockerfile#L11
+version = "2.0.0"
+align.openParenCallSite = false
+continuationIndent.defnSite = 2
+rewrite.rules = [SortImports]

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,37 @@
+import java.io.File
+import java.util.UUID
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider
+
+def setupProject(
+  project: Project,
+  folder: String,
+  localDependencies: Seq[Project] = Seq(),
+  externalDependencies: Seq[ModuleID] = Seq()
+): Project = {
+
+  Metadata.write(project, folder, localDependencies)
+
+  val dependsOn = localDependencies
+    .map { project: Project =>
+      ClasspathDependency(
+        project = project,
+        configuration = Some("compile->compile;test->test")
+      )
+    }
+
+  project
+    .in(new File(folder))
+    .settings(Common.settings: _*)
+    .enablePlugins(JavaAppPackaging)
+    .dependsOn(dependsOn: _*)
+    .settings(libraryDependencies ++= externalDependencies)
+}
+
+// AWS Credentials to read from S3
+s3CredentialsProvider := { _ =>
+  val builder = new STSAssumeRoleSessionCredentialsProvider.Builder(
+    "arn:aws:iam::760097843905:role/platform-ci",
+    UUID.randomUUID().toString
+  )
+  builder.build()
+}

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,0 +1,34 @@
+import sbt.Keys._
+import sbt._
+
+object Common {
+  // Giving this a try for new code (we use 2.12 elsewhere)
+  // If it causes headaches then we can downgrade
+  val projectScalaVersion = "2.13.8"
+
+  val settings: Seq[Def.Setting[_]] = Seq(
+    scalaVersion := projectScalaVersion,
+    organization := "weco",
+    resolvers ++= Seq(
+      "Wellcome releases" at "s3://releases.mvn-repo.wellcomecollection.org/"
+    ),
+    scalacOptions ++= Seq(
+      "-deprecation",
+      "-unchecked",
+      "-encoding",
+      "UTF-8",
+      "-Xlint",
+      "-Xverify",
+      "-Xfatal-warnings",
+      "-feature",
+      "-language:postfixOps",
+      "-Ypartial-unification",
+      "-Xcheckinit"
+    ),
+    updateOptions := updateOptions.value.withCachedResolution(true),
+    Test / parallelExecution := false,
+    // Don't build scaladocs
+    // https://www.scala-sbt.org/sbt-native-packager/formats/universal.html#skip-packagedoc-task-on-stage
+    Compile / packageDoc / mappings := Nil
+  )
+}

--- a/project/Metadata.scala
+++ b/project/Metadata.scala
@@ -1,0 +1,45 @@
+import java.io.File
+
+import sbt.{IO, Project}
+import scala.reflect.io.Directory
+import io.circe.generic.auto._
+import io.circe.syntax._
+
+// TODO this might no longer be necessary, but replicating the setup from other repos for now
+
+object Metadata {
+  // Clear out the .sbt_metadata directory before every invocation of sbt,
+  // so if we change the project structure old metadata entries will
+  // be deleted.
+  val directory = new Directory(new File(".sbt_metadata"))
+  directory.deleteRecursively()
+
+  def write(
+    project: Project,
+    folder: String,
+    localDependencies: Seq[Project] = Seq()
+  ) = {
+    // Here we write a bit of metadata about the project, and the other
+    // local projects it depends on.  This can be used to determine whether
+    // to run tests based on the up-to-date project graph.
+    // See https://www.scala-sbt.org/release/docs/Howto-Generating-Files.html
+    val file = new File(s".sbt_metadata/${project.id}.json")
+    val dependencyIds: List[String] = localDependencies.map { p: Project =>
+      p.id
+    }.toList
+
+    case class ProjectMetadata(
+      id: String,
+      folder: String,
+      dependencyIds: List[String]
+    )
+
+    val metadata = ProjectMetadata(
+      id = project.id,
+      folder = folder,
+      dependencyIds = dependencyIds
+    )
+
+    IO.write(file, metadata.asJson.spaces2)
+  }
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.6.2

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,0 +1,3 @@
+// This is the language version used by SBT, not the repo code that we're building
+// It needs to be 2.12 because that's the version SBT and its plugins use
+scalaVersion := "2.12.16"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,12 @@
+// Circe things are required by the Metadata-writing stuff
+val circeVersion = "0.8.0"
+libraryDependencies ++= Seq(
+  "io.circe" %% "circe-core",
+  "io.circe" %% "circe-generic",
+  "io.circe" %% "circe-parser"
+).map(_ % circeVersion)
+
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.9")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.21.0")
+addDependencyTreePlugin


### PR DESCRIPTION
This cribs a lot from the catalogue-pipeline repo, but it uses updated versions of SBT and its plugins, as well as speculatively using Scala 2.13 for the (to-be-created) projects.

If these upgrades cause problems I don't think we should spend much time on fixing them, but since this is likely to be low-dependency work it seems like a good time to try out newer tooling. 

Since it's not actually compiling anything yet it might need some more fiddling when we get to https://github.com/wellcomecollection/concepts-pipeline/issues/4!