### PR TITLE
Scalafmt in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,8 @@
 steps:
+  - label: "autoformat"
+    command: .buildkite/scripts/autoformat.sh
+    agents:
+      queue: "nano"
   - label: "ingestor"
     command: |
       .buildkite/scripts/sbt.sh "project ingestor" "test"

--- a/.buildkite/scripts/autoformat.sh
+++ b/.buildkite/scripts/autoformat.sh
@@ -3,12 +3,12 @@ set -euo pipefail
 
 SCALAFMT_VERSION=3.5.8
 ROOT=$(git rev-parse --show-toplevel)
+PATH=$HOME/.local/bin:$PATH
 
-echo $PATH
 # Install the formatter if it's not already present on the agent
 if [[ ! -x "$(command -v scalafmt-native)" || "$(scalafmt-native --version)" != "$SCALAFMT_VERSION" ]]; then
   curl https://raw.githubusercontent.com/scalameta/scalafmt/master/bin/install-scalafmt-native.sh | \
-    bash -s -- $SCALAFMT_VERSION /usr/local/bin/scalafmt-native
+    bash -s -- $SCALAFMT_VERSION $HOME/.local/bin/scalafmt-native
 fi
 
 # Run the formatter

--- a/.buildkite/scripts/autoformat.sh
+++ b/.buildkite/scripts/autoformat.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -o errexit
 
 SCALAFMT_VERSION=3.5.8
 ROOT=$(git rev-parse --show-toplevel)
@@ -17,9 +18,9 @@ if [[ `git status --porcelain` ]]; then
   git config user.name "Buildkite on behalf of Wellcome Collection"
   git config user.email "wellcomedigitalplatform@wellcome.ac.uk"
 
-  git remote add ssh-origin $BUILDKITE_REPO
+  git remote add ssh-origin $BUILDKITE_REPO || true
   git fetch ssh-origin
-  git checkout --track ssh-origin/$BUILDKITE_BRANCH
+  git checkout --track ssh-origin/$BUILDKITE_BRANCH || true
 
   git add --verbose --update
   git commit -m "Apply auto-formatting rules"

--- a/.buildkite/scripts/autoformat.sh
+++ b/.buildkite/scripts/autoformat.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+SCALAFMT_VERSION=3.5.8
+ROOT=$(git rev-parse --show-toplevel)
+
+if [[ ! -x "$(command -v scalafmt-native)" || "$(scalafmt-native --version)" != "$SCALAFMT_VERSION" ]]; then
+  curl https://raw.githubusercontent.com/scalameta/scalafmt/master/bin/install-scalafmt-native.sh | \
+    bash -s -- $SCALAFMT_VERSION /usr/local/bin/scalafmt-native
+fi
+
+scalafmt-native --non-interactive $ROOT
+
+if [[ `git status --porcelain` ]]; then
+  git config user.name "Buildkite on behalf of Wellcome Collection"
+  git config user.email "wellcomedigitalplatform@wellcome.ac.uk"
+
+  git remote add ssh-origin $BUILDKITE_REPO
+  git fetch ssh-origin
+  git checkout --track ssh-origin/$BUILDKITE_BRANCH
+
+  git add --verbose --update
+  git commit -m "Apply auto-formatting rules"
+
+  git push ssh-origin HEAD:$BUILDKITE_BRANCH
+  exit 1;
+else
+  echo "There were no changes from auto-formatting"
+  exit 0;
+fi

--- a/.buildkite/scripts/autoformat.sh
+++ b/.buildkite/scripts/autoformat.sh
@@ -7,6 +7,7 @@ PATH=$HOME/.local/bin:$PATH
 
 # Install the formatter if it's not already present on the agent
 if [[ ! -x "$(command -v scalafmt-native)" || "$(scalafmt-native --version)" != "$SCALAFMT_VERSION" ]]; then
+  mkdir -p $HOME/.local/bin
   curl https://raw.githubusercontent.com/scalameta/scalafmt/master/bin/install-scalafmt-native.sh | \
     bash -s -- $SCALAFMT_VERSION $HOME/.local/bin/scalafmt-native
 fi

--- a/.buildkite/scripts/autoformat.sh
+++ b/.buildkite/scripts/autoformat.sh
@@ -3,13 +3,16 @@
 SCALAFMT_VERSION=3.5.8
 ROOT=$(git rev-parse --show-toplevel)
 
+# Install the formatter if it's not already present on the agent
 if [[ ! -x "$(command -v scalafmt-native)" || "$(scalafmt-native --version)" != "$SCALAFMT_VERSION" ]]; then
   curl https://raw.githubusercontent.com/scalameta/scalafmt/master/bin/install-scalafmt-native.sh | \
     bash -s -- $SCALAFMT_VERSION /usr/local/bin/scalafmt-native
 fi
 
+# Run the formatter
 scalafmt-native --non-interactive $ROOT
 
+# Commit any changes
 if [[ `git status --porcelain` ]]; then
   git config user.name "Buildkite on behalf of Wellcome Collection"
   git config user.email "wellcomedigitalplatform@wellcome.ac.uk"

--- a/.buildkite/scripts/autoformat.sh
+++ b/.buildkite/scripts/autoformat.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-set -o errexit
+set -euo pipefail
 
 SCALAFMT_VERSION=3.5.8
 ROOT=$(git rev-parse --show-toplevel)
 
+echo $PATH
 # Install the formatter if it's not already present on the agent
 if [[ ! -x "$(command -v scalafmt-native)" || "$(scalafmt-native --version)" != "$SCALAFMT_VERSION" ]]; then
   curl https://raw.githubusercontent.com/scalameta/scalafmt/master/bin/install-scalafmt-native.sh | \

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,6 +1,7 @@
 # Matches the version here
 # https://github.com/wellcomecollection/dockerfiles/blob/master/scalafmt/Dockerfile#L11
 version = "3.5.8"
+runner.dialect = "scala213"
 align.openParenCallSite = false
 continuationIndent.defnSite = 2
 rewrite.rules = [SortImports]

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,6 +1,6 @@
 # Matches the version here
 # https://github.com/wellcomecollection/dockerfiles/blob/master/scalafmt/Dockerfile#L11
-version = "2.0.0"
+version = "3.5.8"
 align.openParenCallSite = false
 continuationIndent.defnSite = 2
 rewrite.rules = [SortImports]

--- a/ingestor/src/main/scala/weco/concepts/ingestor/Main.scala
+++ b/ingestor/src/main/scala/weco/concepts/ingestor/Main.scala
@@ -1,5 +1,5 @@
 package weco.concepts.ingestor
 
 object Main extends App {
-  println("Hello world, I am a concepts ingestor")
+  println( "Hello world, I am a concepts ingestor")
 }

--- a/ingestor/src/main/scala/weco/concepts/ingestor/Main.scala
+++ b/ingestor/src/main/scala/weco/concepts/ingestor/Main.scala
@@ -1,5 +1,5 @@
 package weco.concepts.ingestor
 
 object Main extends App {
-  println( "Hello world, I am a concepts ingestor")
+  println("Hello world, I am a concepts ingestor")
 }


### PR DESCRIPTION
Sometimes, Docker isn't the right tool: this installs and runs [scalafmt-native](https://scalameta.org/scalafmt/docs/installation.html#native-image) directly on the agent, without the overhead of Docker or the JVM, and all in one short bash script. This means autoformatting takes about 8 seconds.