### PR TITLE
Ingestor boilerplate

### DIFF
--- a/ingestor/src/main/resources/application.conf
+++ b/ingestor/src/main/resources/application.conf
@@ -1,1 +1,1 @@
-data-source.loc.lcsh=https://id.loc.gov/download/authorities/subjects.skosrdf.jsonld.gz
+data-source.loc.lcsh="https://id.loc.gov/download/authorities/subjects.skosrdf.jsonld.gz"

--- a/ingestor/src/main/resources/application.conf
+++ b/ingestor/src/main/resources/application.conf
@@ -1,0 +1,1 @@
+data-source.loc.lcsh=https://id.loc.gov/download/authorities/subjects.skosrdf.jsonld.gz

--- a/ingestor/src/main/resources/logback.xml
+++ b/ingestor/src/main/resources/logback.xml
@@ -1,0 +1,23 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>8192</queueSize>
+        <neverBlock>true</neverBlock>
+        <appender-ref ref="STDOUT"/>
+    </appender>
+
+    <root level="${log_level:-INFO}">
+        <appender-ref ref="ASYNC"/>
+    </root>
+
+    <!-- reduce external logging -->
+    <logger name="org.apache.http" level="ERROR"/>
+    <logger name="io.netty" level="ERROR"/>
+    <logger name="com.amazonaws" level="WARN"/>
+    <logger name="software.amazon.awssdk" level="WARN"/>
+</configuration>

--- a/ingestor/src/main/scala/weco/concepts/ingestor/Main.scala
+++ b/ingestor/src/main/scala/weco/concepts/ingestor/Main.scala
@@ -1,5 +1,12 @@
 package weco.concepts.ingestor
 
-object Main extends App {
-  println("Hello world, I am a concepts ingestor")
+import com.typesafe.config.ConfigFactory
+import grizzled.slf4j.Logging
+import net.ceedubs.ficus.Ficus._
+
+object Main extends App with Logging {
+  val config = ConfigFactory.load()
+  val lcshUrl = config.as[String]("data-source.loc.lcsh")
+
+  info(s"LCSH URL: $lcshUrl")
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,13 +3,31 @@ import sbt._
 object ExternalDependencies {
   lazy val versions = new {
     val scalatest = "3.2.12"
+    val grizzledSlf4j = "1.3.4"
+    val logback = "1.2.11"
+    val typesafeConfig = "1.4.2"
+    val ficus = "1.5.2"
   }
 
   val scalatest = Seq(
     "org.scalatest" %% "scalatest" % versions.scalatest % "test"
   )
+
+  val logging = Seq(
+    "org.clapper" %% "grizzled-slf4j" % versions.grizzledSlf4j,
+    "ch.qos.logback" % "logback-access" % versions.logback,
+    "ch.qos.logback" % "logback-classic" % versions.logback,
+    "ch.qos.logback" % "logback-core" % versions.logback,
+  )
+
+  val config = Seq(
+    "com.typesafe" % "config" % versions.typesafeConfig,
+    "com.iheart" %% "ficus" % versions.ficus
+  )
 }
 
 object ServiceDependencies {
-  val ingestor: Seq[ModuleID] = ExternalDependencies.scalatest
+  import ExternalDependencies._
+
+  val ingestor: Seq[ModuleID] = scalatest ++ logging ++ config
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object ExternalDependencies {
     "org.clapper" %% "grizzled-slf4j" % versions.grizzledSlf4j,
     "ch.qos.logback" % "logback-access" % versions.logback,
     "ch.qos.logback" % "logback-classic" % versions.logback,
-    "ch.qos.logback" % "logback-core" % versions.logback,
+    "ch.qos.logback" % "logback-core" % versions.logback
   )
 
   val config = Seq(


### PR DESCRIPTION
Rather than using our old app boilerplate ([`WellcomeTypesafeApp`](https://github.com/wellcomecollection/scala-libs/tree/main/typesafe_app)) I've put the bare essentials for structured logging and loading Lightbend config in here. We have previously written our own scala wrappers around the config library: there's no need for that, [someone else has done it](https://github.com/iheartradio/ficus).