### PR TITLE
Move the model and json ops to a common lib

### DIFF
--- a/aggregator/Dockerfile
+++ b/aggregator/Dockerfile
@@ -3,9 +3,9 @@ FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper:1.7.1 as 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 WORKDIR /app
-
 COPY ./build.sbt ./
 COPY ./project ./project
+COPY ./common ./common
 COPY ./aggregator ./aggregator
 
 RUN /run_sbt.sh "project aggregator" "stage"

--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,7 @@ lazy val ingestor = setupProject(
 lazy val aggregator = setupProject(
   project,
   folder = "aggregator",
+  localDependencies = Seq(common),
   externalDependencies = ServiceDependencies.aggregator
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -23,10 +23,15 @@ def setupProject(
     .dependsOn(dependsOn: _*)
     .settings(libraryDependencies ++= externalDependencies)
 }
+lazy val common = setupProject(
+  project,
+  "common",
+  externalDependencies = ServiceDependencies.common)
 
 lazy val ingestor = setupProject(
   project,
   folder = "ingestor",
+  localDependencies = Seq(common),
   externalDependencies = ServiceDependencies.ingestor
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,8 @@ def setupProject(
 lazy val common = setupProject(
   project,
   "common",
-  externalDependencies = ServiceDependencies.common)
+  externalDependencies = ServiceDependencies.common
+)
 
 lazy val ingestor = setupProject(
   project,

--- a/common/src/main/scala/weco/concepts/common/json/JsonOps.scala
+++ b/common/src/main/scala/weco/concepts/common/json/JsonOps.scala
@@ -1,4 +1,4 @@
-package weco.concepts.ingestor.json
+package weco.concepts.common.json
 
 import scala.util.Try
 

--- a/common/src/main/scala/weco/concepts/common/model/Concept.scala
+++ b/common/src/main/scala/weco/concepts/common/model/Concept.scala
@@ -1,5 +1,5 @@
 // TODO: These will probably end up living in a common project/library in this repo
-package weco.concepts.ingestor.model
+package weco.concepts.common.model
 
 case class Concept(
   identifier: Identifier,

--- a/common/src/main/scala/weco/concepts/common/model/Concept.scala
+++ b/common/src/main/scala/weco/concepts/common/model/Concept.scala
@@ -1,4 +1,3 @@
-// TODO: These will probably end up living in a common project/library in this repo
 package weco.concepts.common.model
 
 case class Concept(

--- a/common/src/main/scala/weco/concepts/common/model/Identifier.scala
+++ b/common/src/main/scala/weco/concepts/common/model/Identifier.scala
@@ -1,4 +1,3 @@
-// TODO: These will probably end up living in a common project/library in this repo
 package weco.concepts.common.model
 
 case class Identifier(

--- a/common/src/main/scala/weco/concepts/common/model/Identifier.scala
+++ b/common/src/main/scala/weco/concepts/common/model/Identifier.scala
@@ -1,5 +1,5 @@
 // TODO: These will probably end up living in a common project/library in this repo
-package weco.concepts.ingestor.model
+package weco.concepts.common.model
 
 case class Identifier(
   value: String,

--- a/ingestor/Dockerfile
+++ b/ingestor/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 COPY ./build.sbt ./
 COPY ./project ./project
 COPY ./ingestor ./ingestor
+COPY ./common ./common
 
 RUN /run_sbt.sh "project ingestor" "stage"
 

--- a/ingestor/Dockerfile
+++ b/ingestor/Dockerfile
@@ -5,8 +5,8 @@ LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 WORKDIR /app
 COPY ./build.sbt ./
 COPY ./project ./project
-COPY ./ingestor ./ingestor
 COPY ./common ./common
+COPY ./ingestor ./ingestor
 
 RUN /run_sbt.sh "project ingestor" "stage"
 

--- a/ingestor/src/main/scala/weco/concepts/ingestor/IngestStream.scala
+++ b/ingestor/src/main/scala/weco/concepts/ingestor/IngestStream.scala
@@ -5,7 +5,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.scaladsl._
 import grizzled.slf4j.Logging
-import weco.concepts.ingestor.model.{Concept, IdentifierType}
+import weco.concepts.common.model._
 import weco.concepts.ingestor.stages.{Fetcher, Scroll, Transformer}
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/ingestor/src/main/scala/weco/concepts/ingestor/stages/Transformer.scala
+++ b/ingestor/src/main/scala/weco/concepts/ingestor/stages/Transformer.scala
@@ -3,8 +3,9 @@ package weco.concepts.ingestor.stages
 import akka.NotUsed
 import akka.stream.scaladsl._
 import grizzled.slf4j.Logging
-import weco.concepts.ingestor.json.JsonOps._
-import weco.concepts.ingestor.model._
+import weco.concepts.common.json.JsonOps._
+import weco.concepts.common.model._
+
 
 trait Transformer[SourceType <: IdentifierType] {
   def transform(sourceString: String): Option[Concept]

--- a/ingestor/src/main/scala/weco/concepts/ingestor/stages/Transformer.scala
+++ b/ingestor/src/main/scala/weco/concepts/ingestor/stages/Transformer.scala
@@ -6,7 +6,6 @@ import grizzled.slf4j.Logging
 import weco.concepts.common.json.JsonOps._
 import weco.concepts.common.model._
 
-
 trait Transformer[SourceType <: IdentifierType] {
   def transform(sourceString: String): Option[Concept]
 }

--- a/ingestor/src/test/scala/weco/concepts/ingestor/stages/TransformerTest.scala
+++ b/ingestor/src/test/scala/weco/concepts/ingestor/stages/TransformerTest.scala
@@ -2,7 +2,7 @@ package weco.concepts.ingestor.stages
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import weco.concepts.ingestor.model._
+import weco.concepts.common.model._
 
 class TransformerTest extends AnyFunSpec with Matchers {
   describe("LoC transformer") {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -43,15 +43,15 @@ object ExternalDependencies {
 
 object ServiceDependencies {
   import ExternalDependencies._
-  
+
   val common: Seq[ModuleID] =
     uPickle
 
   val ingestor: Seq[ModuleID] =
     scalatest ++
-    logging ++
-    config ++
-    Seq(akka.actorTyped, akka.stream, akka.http, akka.streamTestkit)
+      logging ++
+      config ++
+      Seq(akka.actorTyped, akka.stream, akka.http, akka.streamTestkit)
 
   val aggregator: Seq[ModuleID] = scalatest ++ logging ++ config
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -43,12 +43,14 @@ object ExternalDependencies {
 
 object ServiceDependencies {
   import ExternalDependencies._
-  val common: Seq[ModuleID] = scalatest ++
-    logging ++
-    config ++
+  
+  val common: Seq[ModuleID] =
     uPickle
 
   val ingestor: Seq[ModuleID] =
+    scalatest ++
+    logging ++
+    config ++
     Seq(akka.actorTyped, akka.stream, akka.http, akka.streamTestkit)
 
   val aggregator: Seq[ModuleID] = scalatest ++ logging ++ config

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -49,7 +49,7 @@ object ServiceDependencies {
     uPickle
 
   val ingestor: Seq[ModuleID] =
-      Seq(akka.actorTyped, akka.stream, akka.http, akka.streamTestkit)
+    Seq(akka.actorTyped, akka.stream, akka.http, akka.streamTestkit)
 
   val aggregator: Seq[ModuleID] = scalatest ++ logging ++ config
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -43,12 +43,12 @@ object ExternalDependencies {
 
 object ServiceDependencies {
   import ExternalDependencies._
+  val common: Seq[ModuleID] = scalatest ++
+    logging ++
+    config ++
+    uPickle
 
   val ingestor: Seq[ModuleID] =
-    scalatest ++
-      logging ++
-      config ++
-      uPickle ++
       Seq(akka.actorTyped, akka.stream, akka.http, akka.streamTestkit)
 
   val aggregator: Seq[ModuleID] = scalatest ++ logging ++ config


### PR DESCRIPTION
For now, they are just placed in a single common library.  It may turn out that we want something a bit more granular, but we can cross that bridge when we come to it.