### PR TITLE
Add some missed cases

### DIFF
--- a/aggregator/src/main/scala/weco/concepts/aggregator/ConceptExtractor.scala
+++ b/aggregator/src/main/scala/weco/concepts/aggregator/ConceptExtractor.scala
@@ -9,7 +9,7 @@ import scala.annotation.tailrec
 
 object ConceptExtractor {
   val conceptTypes =
-    Seq("Concept", "Person", "Organisation", "Meeting", "Period")
+    Seq("Concept", "Person", "Organisation", "Meeting", "Period", "Subject")
   def apply(jsonString: String): Seq[UsedConcept] =
     allConcepts(List(ujson.read(jsonString)), Nil).toList
       .distinctBy(_.identifier)
@@ -26,7 +26,7 @@ object ConceptExtractor {
       case Nil => acc
       case _ =>
         val (nextJsons, concepts) = jsons.map {
-          case obj: ujson.Obj if isConcept(obj) => (Nil, UsedConcepts(obj))
+          case obj: ujson.Obj if isConcept(obj) => (obj.obj.values, UsedConcepts(obj))
           case arr: ujson.Arr                   => (arr.arr, Nil)
           case obj: ujson.Obj                   => (obj.obj.values, Nil)
           case _                                => (Nil, Nil)

--- a/aggregator/src/main/scala/weco/concepts/aggregator/ConceptExtractor.scala
+++ b/aggregator/src/main/scala/weco/concepts/aggregator/ConceptExtractor.scala
@@ -26,10 +26,11 @@ object ConceptExtractor {
       case Nil => acc
       case _ =>
         val (nextJsons, concepts) = jsons.map {
-          case obj: ujson.Obj if isConcept(obj) => (obj.obj.values, UsedConcepts(obj))
-          case arr: ujson.Arr                   => (arr.arr, Nil)
-          case obj: ujson.Obj                   => (obj.obj.values, Nil)
-          case _                                => (Nil, Nil)
+          case obj: ujson.Obj if isConcept(obj) =>
+            (obj.obj.values, UsedConcepts(obj))
+          case arr: ujson.Arr => (arr.arr, Nil)
+          case obj: ujson.Obj => (obj.obj.values, Nil)
+          case _              => (Nil, Nil)
         }.unzip
         allConcepts(nextJsons.flatten, acc ++ concepts.flatten)
     }

--- a/aggregator/src/main/scala/weco/concepts/aggregator/ConceptExtractor.scala
+++ b/aggregator/src/main/scala/weco/concepts/aggregator/ConceptExtractor.scala
@@ -14,8 +14,7 @@ object ConceptExtractor {
     allConcepts(List(ujson.read(jsonString)), Nil).toList
       .distinctBy(_.identifier)
 
-  /** Extract concepts from wherever they may be in a JSON document. This makes
-    * the assumption that a concept cannot be within a concept
+  /** Extract concepts from wherever they may be in a JSON document.
     */
   @tailrec
   private def allConcepts(

--- a/aggregator/src/test/scala/weco/concepts/aggregator/ConceptExtractorTest.scala
+++ b/aggregator/src/test/scala/weco/concepts/aggregator/ConceptExtractorTest.scala
@@ -68,11 +68,11 @@ class ConceptExtractorTest
       And(s"the concept's identifier is $identifier")
       concept.identifier.value shouldBe identifier
 
-      And(s"the concept's canonicalIdentifier is $canonicalId")
-      concept.canonicalId shouldBe canonicalId
-
       And(s"the concept's label is $label")
       concept.label shouldBe label
+
+      And(s"the concept's canonicalIdentifier is $canonicalId")
+      concept.canonicalId shouldBe canonicalId
     }
 
     val ontologyTypes = Table(
@@ -249,6 +249,22 @@ class ConceptExtractorTest
       val notJSON = "<hello>world</hello>"
       Then("an exception is raised")
       a[ParseException] should be thrownBy ConceptExtractor(notJSON)
+    }
+
+    Scenario(s"ignore concept-like objects") {
+      Given(s"a document containing a concept-shaped object of type 'Banana'")
+      val sourceConcept = SourceConcept(
+        ontologyType = "Banana"
+      )
+      val json =
+        s"""{
+           |"concepts":[
+            $sourceConcept
+           |]
+           |}""".stripMargin
+      val concepts = ConceptExtractor(json)
+      Then("the concept list is empty")
+      concepts shouldBe Nil
     }
 
     val malformations = Table(

--- a/aggregator/src/test/scala/weco/concepts/aggregator/ConceptExtractorTest.scala
+++ b/aggregator/src/test/scala/weco/concepts/aggregator/ConceptExtractorTest.scala
@@ -75,69 +75,6 @@ class ConceptExtractorTest
       concept.canonicalId shouldBe canonicalId
     }
 
-    val ontologyTypes = Table(
-      "ontologyType",
-      "Concept",
-      "Person",
-      "Organisation",
-      "Meeting",
-      "Period"
-    )
-    forAll(ontologyTypes) { ontologyType =>
-      Scenario(s"extract a concept of type $ontologyType ") {
-        Given(s"a document containing a concept of type $ontologyType")
-        val sourceConcept = SourceConcept(
-          ontologyType = ontologyType
-        )
-        val json =
-          s"""{
-             |"concepts":[
-            $sourceConcept
-             |]
-             |}""".stripMargin
-
-        Then("that concept is extracted")
-        ConceptExtractor(json).loneElement should have(
-          Symbol("label")(sourceConcept.label),
-          Symbol("canonicalId")(sourceConcept.canonicalId)
-        )
-      }
-    }
-
-    val identifierTypes = Table(
-      "identifierType",
-      "lc-subjects",
-      "lc-names",
-      "nlm-mesh",
-      "label-derived"
-    )
-    forAll(identifierTypes) { identifierType =>
-      Scenario(
-        s"extract a concept with an identifier in the $identifierType scheme "
-      ) {
-        Given(
-          s"a document containing a concept with an identifier of type $identifierType"
-        )
-        val sourceConcept = SourceConcept(
-          authority = identifierType
-        )
-        val json =
-          s"""{
-             |"concepts":[
-            $sourceConcept
-             |]
-             |}""".stripMargin
-
-        Then("that concept is extracted")
-        val concept = ConceptExtractor(json).loneElement
-        concept should have(
-          Symbol("label")(sourceConcept.label),
-          Symbol("canonicalId")(sourceConcept.canonicalId)
-        )
-        concept.identifier.identifierType.id shouldBe identifierType
-      }
-    }
-
     Scenario("extract multiple different concepts throughout the document") {
       info("Concepts may be found in various places in a document")
       info("The extractor can extract them wherever they might be")
@@ -154,7 +91,7 @@ class ConceptExtractorTest
          |  "wotsit": {
          |    "thingummy": ${SourceConcept()},
          |    "wotsit": ${SourceConcept()},
-         |    "stuff":[${SourceConcept()}, ${SourceConcept()}]
+         |    "stuff":[${SourceConcept()}, ${SourceConcept()}],
          |  }
          |}
          |}""".stripMargin
@@ -183,7 +120,7 @@ class ConceptExtractorTest
       And("the label is that of the first concept")
       concepts.loneElement.label shouldBe "Isaac Newton"
     }
-
+    
     Scenario("extract a source Concept with multiple identifiers") {
       // If a source concept has multiple identifiers, then this
       // results in multiple concepts in the output.
@@ -233,6 +170,74 @@ class ConceptExtractorTest
       concepts(1).canonicalId shouldBe "z6m7z2uz"
       concepts(1).identifier.identifierType.id shouldBe identifierType2
       concepts(1).identifier.value shouldBe identifier2
+    }
+  }
+
+  Feature("Different types of Concept") {
+    val ontologyTypes = Table(
+      "ontologyType",
+      "Concept",
+      "Person",
+      "Organisation",
+      "Meeting",
+      "Period",
+      "Subject"
+    )
+    forAll(ontologyTypes) { ontologyType =>
+      Scenario(s"extract a concept of type $ontologyType ") {
+        Given(s"a document containing a concept of type $ontologyType")
+        val sourceConcept = SourceConcept(
+          ontologyType = ontologyType
+        )
+        val json =
+          s"""{
+             |"concepts":[
+              $sourceConcept
+             |]
+             |}""".stripMargin
+
+        Then("that concept is extracted")
+        ConceptExtractor(json).loneElement should have(
+          Symbol("label")(sourceConcept.label),
+          Symbol("canonicalId")(sourceConcept.canonicalId)
+        )
+      }
+    }
+
+    val identifierTypes = Table(
+      "identifierType",
+      "lc-subjects",
+      "lc-names",
+      "nlm-mesh",
+      "label-derived",
+      "fihrist",
+      "viaf"
+    )
+    forAll(identifierTypes) { identifierType =>
+      Scenario(
+        s"extract a concept with an identifier in the $identifierType scheme "
+      ) {
+        Given(
+          s"a document containing a concept with an identifier of type $identifierType"
+        )
+        val sourceConcept = SourceConcept(
+          authority = identifierType
+        )
+        val json =
+          s"""{
+             |"concepts":[
+              $sourceConcept
+             |]
+             |}""".stripMargin
+
+        Then("that concept is extracted")
+        val concept = ConceptExtractor(json).loneElement
+        concept should have(
+          Symbol("label")(sourceConcept.label),
+          Symbol("canonicalId")(sourceConcept.canonicalId)
+        )
+        concept.identifier.identifierType.id shouldBe identifierType
+      }
     }
   }
   Feature("Handling bad input") {

--- a/aggregator/src/test/scala/weco/concepts/aggregator/ConceptExtractorTest.scala
+++ b/aggregator/src/test/scala/weco/concepts/aggregator/ConceptExtractorTest.scala
@@ -32,7 +32,7 @@ class ConceptExtractorTest
       // extracted.  This is just to demonstrate that it can successfully
       // find the concepts in a real document from the catalogue api.
       Then("all the concepts in the work are returned")
-      concepts.length shouldBe 6
+      concepts.length shouldBe 8
     }
 
     Scenario(s"extract the data from a concept") {
@@ -91,7 +91,7 @@ class ConceptExtractorTest
          |  "wotsit": {
          |    "thingummy": ${SourceConcept()},
          |    "wotsit": ${SourceConcept()},
-         |    "stuff":[${SourceConcept()}, ${SourceConcept()}],
+         |    "stuff":[${SourceConcept()}, ${SourceConcept()}]
          |  }
          |}
          |}""".stripMargin
@@ -120,7 +120,70 @@ class ConceptExtractorTest
       And("the label is that of the first concept")
       concepts.loneElement.label shouldBe "Isaac Newton"
     }
-    
+
+    Scenario("extract a Concept from within another Concept") {
+      info("a document may contain compound concepts")
+      info("in which a concept or list of concepts may be nested within a parent concept")
+      info("in real examples, Subjects are a kind of Concept operate this way")
+      Given("a document with a concept object nested within another concept object")
+      val json =
+        s"""
+           |{
+           |  "id": "z6m7z2uz",
+           |  "identifiers": [
+           |    {
+           |      "identifierType": {
+           |        "id": "lc-subjects",
+           |        "label": "This field is ignored",
+           |        "type": "IdentifierType"
+           |      },
+           |      "value": "sh85046693",
+           |      "type": "Identifier"
+           |    }
+           |  ],
+           |  "label": "Eye-sockets--Diseases",
+           |  "type": "Subject",
+           |  "concepts":[
+           |  {
+           |  "id": "cafef00d",
+           |  "identifiers": [
+           |    {
+           |      "identifierType": {
+           |        "id": "lc-subjects",
+           |        "label": "This field is ignored",
+           |        "type": "IdentifierType"
+           |      },
+           |      "value": "sh85046691",
+           |      "type": "Identifier"
+           |    }
+           |  ],
+           |  "label": "Eye-sockets",
+           |  "type": "Concept"
+           |  },
+           |  {
+           |  "id": "cafebeef",
+           |  "identifiers": [
+           |    {
+           |      "identifierType": {
+           |        "id": "lc-subjects",
+           |        "label": "This field is ignored",
+           |        "type": "IdentifierType"
+           |      },
+           |      "value": "sh99002330",
+           |      "type": "Identifier"
+           |    }
+           |  ],
+           |  "label": "Diseases",
+           |  "type": "Concept"
+           |  }
+           | ]
+           |}
+           |""".stripMargin
+      val concepts = ConceptExtractor(json)
+      Then("both concepts are returned")
+      concepts.length shouldBe 3
+    }
+
     Scenario("extract a source Concept with multiple identifiers") {
       // If a source concept has multiple identifiers, then this
       // results in multiple concepts in the output.

--- a/aggregator/src/test/scala/weco/concepts/aggregator/ConceptExtractorTest.scala
+++ b/aggregator/src/test/scala/weco/concepts/aggregator/ConceptExtractorTest.scala
@@ -228,7 +228,7 @@ class ConceptExtractorTest
       concepts.head.identifier.identifierType.id shouldBe identifierType1
       concepts.head.identifier.value shouldBe identifier1
       And(
-        "the second Concept contains thecanonicalid and the second identifier"
+        "the second Concept contains the canonicalid and the second identifier"
       )
       concepts(1).canonicalId shouldBe "z6m7z2uz"
       concepts(1).identifier.identifierType.id shouldBe identifierType2
@@ -339,7 +339,7 @@ class ConceptExtractorTest
     )
     forAll(malformations) { (malformation, badJson) =>
       Scenario(s"encountering a malformed concept - $malformation") {
-        Given("a document with a valid concept and an invalid concept")
+        Given(s"a document with a valid concept and a concept with $malformation")
         val jsonString =
           s"""
              |{

--- a/aggregator/src/test/scala/weco/concepts/aggregator/ConceptExtractorTest.scala
+++ b/aggregator/src/test/scala/weco/concepts/aggregator/ConceptExtractorTest.scala
@@ -123,9 +123,13 @@ class ConceptExtractorTest
 
     Scenario("extract a Concept from within another Concept") {
       info("a document may contain compound concepts")
-      info("in which a concept or list of concepts may be nested within a parent concept")
+      info(
+        "in which a concept or list of concepts may be nested within a parent concept"
+      )
       info("in real examples, Subjects are a kind of Concept operate this way")
-      Given("a document with a concept object nested within another concept object")
+      Given(
+        "a document with a concept object nested within another concept object"
+      )
       val json =
         s"""
            |{
@@ -407,7 +411,9 @@ class ConceptExtractorTest
     )
     forAll(malformations) { (malformation, badJson) =>
       Scenario(s"encountering a malformed concept - $malformation") {
-        Given(s"a document with a valid concept and a concept with $malformation")
+        Given(
+          s"a document with a valid concept and a concept with $malformation"
+        )
         val jsonString =
           s"""
              |{

--- a/common/src/main/scala/weco/concepts/common/model/Identifier.scala
+++ b/common/src/main/scala/weco/concepts/common/model/Identifier.scala
@@ -12,6 +12,9 @@ sealed trait IdentifierType {
 }
 
 object IdentifierType {
+  case object Fihrist extends IdentifierType {
+    val id = "fihrist"
+  }
   case object LabelDerived extends IdentifierType {
     val id = "label-derived"
   }
@@ -24,6 +27,10 @@ object IdentifierType {
   case object MeSH extends IdentifierType {
     val id = "nlm-mesh"
   }
+  case object Viaf extends IdentifierType {
+    val id = "viaf"
+  }
+
   val typeMap: Map[String, IdentifierType] =
-    Seq(LCSubjects, LCNames, MeSH, LabelDerived).map(i => i.id -> i).toMap
+    Seq(Fihrist, LabelDerived, LCNames, LCSubjects, MeSH, Viaf).map(i => i.id -> i).toMap
 }

--- a/common/src/main/scala/weco/concepts/common/model/Identifier.scala
+++ b/common/src/main/scala/weco/concepts/common/model/Identifier.scala
@@ -32,5 +32,7 @@ object IdentifierType {
   }
 
   val typeMap: Map[String, IdentifierType] =
-    Seq(Fihrist, LabelDerived, LCNames, LCSubjects, MeSH, Viaf).map(i => i.id -> i).toMap
+    Seq(Fihrist, LabelDerived, LCNames, LCSubjects, MeSH, Viaf)
+      .map(i => i.id -> i)
+      .toMap
 }

--- a/common/src/main/scala/weco/concepts/common/model/Identifier.scala
+++ b/common/src/main/scala/weco/concepts/common/model/Identifier.scala
@@ -12,17 +12,17 @@ sealed trait IdentifierType {
 }
 
 object IdentifierType {
-  case object LCSubjects extends IdentifierType {
-    val id = "lc-subjects"
+  case object LabelDerived extends IdentifierType {
+    val id = "label-derived"
   }
   case object LCNames extends IdentifierType {
     val id = "lc-names"
   }
+  case object LCSubjects extends IdentifierType {
+    val id = "lc-subjects"
+  }
   case object MeSH extends IdentifierType {
     val id = "nlm-mesh"
-  }
-  case object LabelDerived extends IdentifierType {
-    val id = "label-derived"
   }
   val typeMap: Map[String, IdentifierType] =
     Seq(LCSubjects, LCNames, MeSH, LabelDerived).map(i => i.id -> i).toMap


### PR DESCRIPTION
Identifier types from TEI

Subjects are Concepts too.  However, they also contain concepts.

At some point in the future, we may do away with subjects as concepts, but at the moment it's the only way we can handle compound concepts (in particular, compound LoC concepts, whose ids are opaque, unlike MeSH)