### PR TITLE
Aggregator as fat jar

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+**/Dockerfile
+**/docker-compose
+**/*md
+**/scripts
+**/target

--- a/aggregator/Dockerfile
+++ b/aggregator/Dockerfile
@@ -9,14 +9,12 @@ COPY ./project ./project
 RUN /run_sbt.sh "project aggregator" "update"
 COPY ./common ./common
 COPY ./aggregator ./aggregator
-RUN /run_sbt.sh "project aggregator" "stage"
-
+RUN /run_sbt.sh "project aggregator" "assembly"
 ENTRYPOINT ["/run_sbt.sh", "project aggregator"]
 
-FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine as runtime
 
 RUN apk add --no-cache bash
 
-COPY --from=sbt /app/aggregator/target/universal/stage /opt/docker
-
-ENTRYPOINT ["/opt/docker/bin/aggregator"]
+COPY --from=sbt /app/target/aggregator.jar /opt/docker/
+ENTRYPOINT ["java", "-jar", "/opt/docker/aggregator.jar"]

--- a/aggregator/Dockerfile
+++ b/aggregator/Dockerfile
@@ -9,6 +9,9 @@ COPY ./project ./project
 RUN /run_sbt.sh "project aggregator" "update"
 COPY ./common ./common
 COPY ./aggregator ./aggregator
+# Build a fat jar, as recommended for lambda here:
+# https://deepdive.codiply.com/aws-lambda-function-in-scala-with-container-image
+# https://aws.amazon.com/blogs/compute/writing-aws-lambda-functions-in-scala/
 RUN /run_sbt.sh "project aggregator" "assembly"
 ENTRYPOINT ["/run_sbt.sh", "project aggregator"]
 

--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,18 @@ lazy val aggregator = setupProject(
   folder = "aggregator",
   localDependencies = Seq(common),
   externalDependencies = ServiceDependencies.aggregator
+).settings(
+  assembly / assemblyOutputPath := file("target/aggregator.jar"),
+  assembly / mainClass := Some("weco.concepts.aggregator.Main"),
+  assembly / assemblyMergeStrategy := {
+    case PathList(ps @ _*) if ps.last == "module-info.class" =>
+      // The module-info.class files in logback-classic and logback-core clash.
+      MergeStrategy.rename
+    case x =>
+      // Do whatever the default is for this file.
+      val oldStrategy = (ThisBuild / assemblyMergeStrategy).value
+      oldStrategy(x)
+  }
 )
 
 // AWS Credentials to read from S3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.9")
 addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.21.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")


### PR DESCRIPTION
This introduces the building of a fat jar, as recommended for running scala on lambda, either from an image or as a jar runtime:

https://deepdive.codiply.com/aws-lambda-function-in-scala-with-container-image
https://aws.amazon.com/blogs/compute/writing-aws-lambda-functions-in-scala/

I've also added a dockerignore to make Docker a bit less prone to invalidating the layer cache when we change something irrelevant.