### PR TITLE
Filter out 781 identifiers

### DIFF
--- a/aggregator/src/main/scala/weco/concepts/aggregator/UsedConceptFormatter.scala
+++ b/aggregator/src/main/scala/weco/concepts/aggregator/UsedConceptFormatter.scala
@@ -7,11 +7,15 @@ import weco.concepts.common.model.UsedConcept
   * update request.
   */
 object UsedConceptFormatter extends BulkFormatter[UsedConcept] {
-  def identifier(concept: UsedConcept): String = concept.identifier.toString
-  def doc(concept: UsedConcept): ujson.Obj = ujson.Obj(
-    "authority" -> concept.identifier.identifierType.id,
-    "identifier" -> concept.identifier.value,
-    "label" -> concept.label,
-    "canonicalId" -> concept.canonicalId
+  def identifier(concept: UsedConcept): Option[String] = Some(
+    concept.identifier.toString
+  )
+  def doc(concept: UsedConcept): Option[ujson.Obj] = Some(
+    ujson.Obj(
+      "authority" -> concept.identifier.identifierType.id,
+      "identifier" -> concept.identifier.value,
+      "label" -> concept.label,
+      "canonicalId" -> concept.canonicalId
+    )
   )
 }

--- a/aggregator/src/test/scala/weco/concepts/aggregator/UsedConceptFormatterTest.scala
+++ b/aggregator/src/test/scala/weco/concepts/aggregator/UsedConceptFormatterTest.scala
@@ -36,7 +36,7 @@ class UsedConceptFormatterTest
           canonicalId = "baadbeef"
         )
       When("format is called")
-      val formatted: String = formatter(concept)
+      val formatted: String = formatter(concept).get
       Then("the result is two lines of NDJSON")
       val lines = formatted.linesIterator.toList
       lines.length shouldBe 2

--- a/common/src/test/scala/weco/concepts/common/elasticsearch/BulkUpdateFlowTest.scala
+++ b/common/src/test/scala/weco/concepts/common/elasticsearch/BulkUpdateFlowTest.scala
@@ -5,13 +5,14 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.scaladsl.TestSink
-import org.scalatest.funspec.AsyncFunSpec
+import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.concepts.common.fixtures.TestElasticHttpClient
 
 import scala.util.Success
+import scala.concurrent.ExecutionContext.Implicits.global
 
-class BulkUpdateFlowTest extends AsyncFunSpec with Matchers {
+class BulkUpdateFlowTest extends AnyFunSpec with Matchers {
   implicit val actorSystem: ActorSystem = ActorSystem("test")
   val client = new TestElasticHttpClient({
     case HttpRequest(HttpMethods.POST, uri, _, entity, _)
@@ -49,9 +50,12 @@ class BulkUpdateFlowTest extends AsyncFunSpec with Matchers {
 
   case class TestDoc(id: String, value: Int)
   object TestDocFormatter extends BulkFormatter[TestDoc] {
-    def identifier(item: TestDoc): String = item.id
-    def doc(item: TestDoc): ujson.Obj =
-      ujson.Obj("id" -> item.id, "value" -> item.value)
+    def identifier(item: TestDoc): Option[String] = item.id match {
+      case "none" => None
+      case id     => Some(id)
+    }
+    def doc(item: TestDoc): Option[ujson.Obj] =
+      Some(ujson.Obj("id" -> item.id, "value" -> item.value))
   }
 
   it("bulk indexes records in groups") {
@@ -74,5 +78,25 @@ class BulkUpdateFlowTest extends AsyncFunSpec with Matchers {
 
     results.map(_.getOrElse("total", 0)).sum shouldBe nDocs
     client.requests.length shouldBe nDocs / groupSize
+  }
+
+  it("filters out items that aren't transformed successfully") {
+    val bulkUpdateFlow = new BulkUpdateFlow[TestDoc](
+      formatter = TestDocFormatter,
+      max_bulk_records = 10,
+      elasticHttpClient = client,
+      indexName = "test-index"
+    )
+    val documents = Seq(
+      TestDoc(id = "none", value = 123),
+      TestDoc(id = "some", value = 456)
+    )
+
+    Source(documents)
+      .via(bulkUpdateFlow.flow)
+      .runWith(TestSink.probe[Map[String, Int]])
+      .request(1)
+      .expectNext(Map("created" -> 1, "total" -> 1))
+      .expectComplete()
   }
 }

--- a/ingestor/src/main/scala/weco/concepts/ingestor/ConceptFormatter.scala
+++ b/ingestor/src/main/scala/weco/concepts/ingestor/ConceptFormatter.scala
@@ -1,14 +1,29 @@
 package weco.concepts.ingestor
 
 import weco.concepts.common.elasticsearch.BulkFormatter
-import weco.concepts.common.model.Concept
+import weco.concepts.common.model.{Concept, Identifier, IdentifierType}
 
 object ConceptFormatter extends BulkFormatter[Concept] {
-  def identifier(concept: Concept): String = concept.identifier.toString
-  def doc(concept: Concept): ujson.Obj = ujson.Obj(
-    "authority" -> concept.identifier.identifierType.id,
-    "identifier" -> concept.identifier.value,
-    "label" -> concept.label,
-    "alternativeLabels" -> concept.alternativeLabels
+  // Some LCSH identifiers have a suffix, `-781`
+  // This seems to be a way of representing a subdivision
+  // linking for geographic entities: in practice, an alternative
+  // name for a place. We don't really care about these
+  // as they're not used in our catalogue, and it would be non-trivial
+  // to work out how to merge the subdivisions with their parents,
+  // so we just filter them out here.
+  def identifier(concept: Concept): Option[String] = concept.identifier match {
+    case Identifier(value, IdentifierType.LCSubjects, _)
+        if value.endsWith("-781") =>
+      None
+    case id => Some(id.toString)
+  }
+
+  def doc(concept: Concept): Option[ujson.Obj] = Some(
+    ujson.Obj(
+      "authority" -> concept.identifier.identifierType.id,
+      "identifier" -> concept.identifier.value,
+      "label" -> concept.label,
+      "alternativeLabels" -> concept.alternativeLabels
+    )
   )
 }

--- a/ingestor/src/test/scala/weco/concepts/ingestor/ConceptFormatterTest.scala
+++ b/ingestor/src/test/scala/weco/concepts/ingestor/ConceptFormatterTest.scala
@@ -1,0 +1,19 @@
+package weco.concepts.ingestor
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.concepts.common.model.{Concept, Identifier, IdentifierType}
+
+class ConceptFormatterTest extends AnyFunSpec with Matchers {
+  it("does not return documents for geographic subdivision records") {
+    val concept = Concept(
+      identifier = Identifier(
+        value = "sh2014000619-781",
+        identifierType = IdentifierType.LCSubjects
+      ),
+      label = "Gabon--Parc national de Loango",
+      alternativeLabels = Nil
+    )
+    ConceptFormatter.format("test")(concept) shouldBe None
+  }
+}


### PR DESCRIPTION
These are the only non-standard identifiers in the LoC sources - thought about doing some clever merging with them (as they behave like alternative labels) but decided that since we don't really care about them, we should just get rid of them