### PR TITLE
use havepropertymatcher for CatalogueConcepts rather than reflection

### DIFF
--- a/aggregator/src/test/scala/weco/concepts/aggregator/ConceptExtractorTest.scala
+++ b/aggregator/src/test/scala/weco/concepts/aggregator/ConceptExtractorTest.scala
@@ -11,12 +11,14 @@ import weco.concepts.aggregator.testhelpers.{
   SourceCompoundConcept,
   SourceConcept
 }
+import weco.concepts.common.model.matchers.CatalogueConceptMatchers
 
 class ConceptExtractorTest
     extends AnyFeatureSpec
     with Matchers
     with GivenWhenThen
-    with TableDrivenPropertyChecks {
+    with TableDrivenPropertyChecks
+    with CatalogueConceptMatchers {
   Feature("Extracting Concepts from a document") {
     info("The concept extractor extracts concepts from a single json document")
     info("The resulting content from this process consists of the following")
@@ -338,8 +340,8 @@ class ConceptExtractorTest
         Then("that concept is extracted")
         val concept = ConceptExtractor(json).loneElement
         concept should have(
-          Symbol("label")(sourceConcept.label),
-          Symbol("canonicalId")(sourceConcept.canonicalId)
+          label(sourceConcept.label),
+          canonicalId(sourceConcept.canonicalId)
         )
         concept.identifier.identifierType.id shouldBe identifierType
       }

--- a/common/src/test/scala/weco/concepts/common/model/matchers/CatalogueConceptMatchers.scala
+++ b/common/src/test/scala/weco/concepts/common/model/matchers/CatalogueConceptMatchers.scala
@@ -1,0 +1,51 @@
+package weco.concepts.common.model.matchers
+
+import weco.concepts.common.model.{CatalogueConcept, Identifier}
+import org.scalatest.matchers.{HavePropertyMatchResult, HavePropertyMatcher}
+
+trait CatalogueConceptMatchers {
+  def identifier(
+    expectedValue: Identifier
+  ): HavePropertyMatcher[CatalogueConcept, Identifier] =
+    (concept: CatalogueConcept) =>
+      HavePropertyMatchResult(
+        concept.identifier == expectedValue,
+        "identifier",
+        expectedValue,
+        concept.identifier
+      )
+
+  def label(
+    expectedValue: String
+  ): HavePropertyMatcher[CatalogueConcept, String] =
+    (concept: CatalogueConcept) =>
+      HavePropertyMatchResult(
+        concept.label == expectedValue,
+        "label",
+        expectedValue,
+        concept.label
+      )
+
+  def canonicalId(
+    expectedValue: String
+  ): HavePropertyMatcher[CatalogueConcept, String] =
+    (concept: CatalogueConcept) =>
+      HavePropertyMatchResult(
+        concept.canonicalId == expectedValue,
+        "canonicalId",
+        expectedValue,
+        concept.canonicalId
+      )
+
+  def ontologyType(
+    expectedValue: String
+  ): HavePropertyMatcher[CatalogueConcept, String] =
+    (concept: CatalogueConcept) =>
+      HavePropertyMatchResult(
+        concept.ontologyType == expectedValue,
+        "ontologyType",
+        expectedValue,
+        concept.ontologyType
+      )
+
+}


### PR DESCRIPTION
This makes the tests look a bit neater, but also makes it a bit more convenient when changing the behaviour of CatalogueConcept in the future.