### PR TITLE
Short circuit noop

### DIFF
--- a/aggregator/src/main/scala/weco/concepts/aggregator/ConceptsAggregator.scala
+++ b/aggregator/src/main/scala/weco/concepts/aggregator/ConceptsAggregator.scala
@@ -30,12 +30,26 @@ class ConceptsAggregator(
     maxBulkRecords = maxRecordsPerBulkRequest,
     indexName = indexName
   ).flow
+
+  private val notInIndexFlow = new NotInIndexFlow(
+    elasticHttpClient = elasticHttpClient,
+    indexName = indexName
+  ).flow
+
   private val indices = new Indices(elasticHttpClient)
 
   def run(jsonSource: Source[String, NotUsed]): Future[Done] = {
     indices.create(indexName).flatMap { _ =>
       conceptSource(jsonSource)
         .via(deduplicateFlow)
+        // At bulk scale, scripted updates are prohibitively slow.
+        // It is much quicker to first check if the canonicalId is present
+        // before attempting to send it to ES.
+        //
+        // This has no effect when indexing into a pristine database.
+        // The use of deduplicateFlow, above, means that no duplicate ids
+        // will be found by notInIndexFlow.
+        .via(notInIndexFlow)
         .via(bulkUpdateFlow)
         .runWith(publishIds)
     }

--- a/aggregator/src/main/scala/weco/concepts/aggregator/ConceptsAggregator.scala
+++ b/aggregator/src/main/scala/weco/concepts/aggregator/ConceptsAggregator.scala
@@ -35,7 +35,6 @@ class ConceptsAggregator(
     elasticHttpClient = elasticHttpClient,
     indexName = indexName
   ).flow
-  println(notInIndexFlow)
   private val indices = new Indices(elasticHttpClient)
 
   def run(jsonSource: Source[String, NotUsed]): Future[Done] = {
@@ -49,7 +48,7 @@ class ConceptsAggregator(
         // This has no effect when indexing into a pristine database.
         // The use of deduplicateFlow, above, means that no duplicate ids
         // will be found by notInIndexFlow.
-//        .via(notInIndexFlow)
+        .via(notInIndexFlow)
         .via(bulkUpdateFlow)
         .runWith(publishIds)
     }

--- a/aggregator/src/main/scala/weco/concepts/aggregator/ConceptsAggregator.scala
+++ b/aggregator/src/main/scala/weco/concepts/aggregator/ConceptsAggregator.scala
@@ -35,7 +35,7 @@ class ConceptsAggregator(
     elasticHttpClient = elasticHttpClient,
     indexName = indexName
   ).flow
-
+  println(notInIndexFlow)
   private val indices = new Indices(elasticHttpClient)
 
   def run(jsonSource: Source[String, NotUsed]): Future[Done] = {
@@ -49,7 +49,7 @@ class ConceptsAggregator(
         // This has no effect when indexing into a pristine database.
         // The use of deduplicateFlow, above, means that no duplicate ids
         // will be found by notInIndexFlow.
-        .via(notInIndexFlow)
+//        .via(notInIndexFlow)
         .via(bulkUpdateFlow)
         .runWith(publishIds)
     }

--- a/aggregator/src/main/scala/weco/concepts/aggregator/NotInIndexFlow.scala
+++ b/aggregator/src/main/scala/weco/concepts/aggregator/NotInIndexFlow.scala
@@ -1,0 +1,149 @@
+package weco.concepts.aggregator
+
+import akka.NotUsed
+import akka.http.scaladsl.model.{
+  ContentTypes,
+  HttpEntity,
+  HttpMethods,
+  HttpRequest,
+  HttpResponse,
+  StatusCodes
+}
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.Materializer
+import akka.stream.scaladsl.Flow
+import grizzled.slf4j.Logging
+import ujson.Value
+import weco.concepts.common.elasticsearch.ElasticHttpClient
+import weco.concepts.common.json.JsonOps._
+import weco.concepts.common.model.CatalogueConcept
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+/** This flow filters catalogue concepts on whether a Concept's canonicalId
+  * already exists in the index, allowing the bulk update to only push unseen
+  * ids to Elasticsearch.
+  *
+  * At bulk scale, scripted updates are prohibitively slow, because there is no
+  * way for Elasticsearch to short-circuit the update to a NOOP. This flow
+  * provides that NOOP shortcut.
+  *
+  * This has no significant effect on the speed of indexing the API snapshot
+  * into a pristine database with a simple doc-based bulk upsert, but brings the
+  * time taken to run the scripted version down to match the simple method.
+  *
+  * As an example, running the bulk import (scripted) locally using docker
+  * compose took 1 hour without this and 6 minutes with.
+  */
+class NotInIndexFlow(
+  elasticHttpClient: ElasticHttpClient,
+  indexName: String,
+  maxTerms: Int = 10000 // default max for a terms query is 10k.
+)(implicit mat: Materializer, ec: ExecutionContext)
+    extends Logging {
+
+  def flow: Flow[CatalogueConcept, CatalogueConcept, NotUsed] =
+    Flow[CatalogueConcept]
+      .grouped(maxTerms)
+      .via(findMissingCanonicalIds)
+      .mapConcat(identity)
+
+  private def queryBody(concepts: Seq[CatalogueConcept]): String = ujson.write(
+    ujson.Obj(
+      "size" -> maxTerms,
+      // We are only interested in canonicalId, so that it can be match against
+      // canonicalIds in the input group of Concepts. Just return that from
+      // stored fields.
+      // As well as performance, this has the added advantage that canonicalId will always be
+      // a list, regardless of how many canonicalIds a record has (as opposed to _source.canonicalId
+      // which will either be a string or a list of strings)
+      "_source" -> false,
+      "fields" -> Seq("canonicalId"),
+      "query" -> ujson.Obj(
+        "bool" -> ujson.Obj(
+          // Use filter context.  As well as avoiding scoring, this allows ES to use its magic bitset caching
+          // Most concepts are expected to appear more than once in the Works corpus
+          // so if we are lucky with cache evictions, this can make a bulk update a bit quicker.
+          "filter" -> Seq(
+            ujson.Obj(
+              "terms" -> ujson.Obj(
+                "canonicalId" -> concepts.map(_.canonicalId)
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+
+  private def findMissingCanonicalIds
+    : Flow[Seq[CatalogueConcept], Seq[CatalogueConcept], NotUsed] = {
+    Flow[Seq[CatalogueConcept]]
+      .map { concepts =>
+        HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"/$indexName/_search?filter_path=hits.hits.fields.canonicalId",
+          entity =
+            HttpEntity(ContentTypes.`application/json`, queryBody(concepts))
+        ) -> concepts
+      }
+      .via(elasticHttpClient.flow[Seq[CatalogueConcept]])
+      .map {
+        case (Success(response), concepts) if response.status.isSuccess() =>
+          (response, concepts)
+        case (Success(errorResponse), _) =>
+          error("Error response returned when checking for existing ids")
+          throw new RuntimeException(s"Response: $errorResponse")
+        case (Failure(exception), _) =>
+          error("Unexpected error when checking for existing ids")
+          throw exception
+      }
+      .mapAsync(1) {
+        case (
+              HttpResponse(StatusCodes.OK, _, entity, _),
+              concepts
+            ) =>
+          Unmarshal(entity)
+            .to[String]
+            .map { responseBody: String =>
+              filterExistingConcepts(concepts, responseBody)
+            }
+        case (_, concepts) =>
+          Future(concepts)
+      }
+  }
+
+  private def filterExistingConcepts(
+    concepts: Seq[CatalogueConcept],
+    responseBody: String
+  ): Seq[CatalogueConcept] = {
+    ujson
+      .read(responseBody)
+      .opt[Seq[Value]]("hits", "hits")
+      .flatMap { hits =>
+        Option(
+          hits
+            .flatMap(_.opt[Seq[Value]]("fields", "canonicalId"))
+            .flatMap { canonicalIds: Seq[Value] =>
+              canonicalIds.map(_.str)
+            }
+        )
+      } match {
+      // It is possible that there are no matches at all.  In this case, there will be no hits.hits.fields.canonicalId
+      // In this case, all of the concepts in the batch are "new".
+      case None =>
+        info(s"from ${concepts.length} ids, none were already in the index")
+        concepts
+      // Otherwise, filter out any concepts from the initial batch whose canonicalId is already in the database.
+      case Some(seq) =>
+        val foundIds: Set[String] = seq.toSet
+        val missingConcepts =
+          concepts.filter(concept => !foundIds.contains(concept.canonicalId))
+        info(
+          s"from ${concepts.length} ids, found ${concepts.length - missingConcepts.length} already in the index"
+        )
+        missingConcepts
+    }
+  }
+}

--- a/aggregator/src/test/scala/weco/concepts/aggregator/NotInIndexFlowTest.scala
+++ b/aggregator/src/test/scala/weco/concepts/aggregator/NotInIndexFlowTest.scala
@@ -1,0 +1,174 @@
+package weco.concepts.aggregator
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.{
+  ContentTypes,
+  HttpEntity,
+  HttpMethods,
+  HttpRequest,
+  HttpResponse,
+  StatusCodes
+}
+import akka.stream.scaladsl.Source
+import akka.stream.testkit.scaladsl.TestSink
+import org.scalatest.GivenWhenThen
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.featurespec.AnyFeatureSpec
+import weco.concepts.aggregator.testhelpers.ValueGenerators
+import weco.concepts.common.elasticsearch.ElasticHttpClient
+import weco.concepts.common.fixtures.TestElasticHttpClient
+import weco.concepts.common.model.{CatalogueConcept, Identifier, IdentifierType}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.Success
+
+class NotInIndexFlowTest
+    extends AnyFeatureSpec
+    with Matchers
+    with GivenWhenThen
+    with ValueGenerators {
+
+  private implicit val actorSystem: ActorSystem = ActorSystem("test")
+  private val indexName: String = "my-test-index"
+
+  private def givenSomeConcepts(n: Int): Seq[CatalogueConcept] =
+    (101 to (100 + n)).map(i =>
+      CatalogueConcept(
+        identifier = Identifier(
+          value = s"n12345678$i",
+          identifierType = IdentifierType.LCNames
+        ),
+        label = s"The concept of $i",
+        canonicalId = s"abcdef$i",
+        ontologyType = "Concept"
+      )
+    )
+  private def givenAnIndex(queryResponse: String): TestElasticHttpClient =
+    TestElasticHttpClient({
+      case HttpRequest(HttpMethods.POST, uri, _, _, _)
+          if uri.path
+            .toString() == s"/$indexName/_search" &&
+            uri.rawQueryString.get == "filter_path=hits.hits.fields.canonicalId" =>
+        Success(
+          HttpResponse(
+            StatusCodes.OK,
+            entity = HttpEntity(
+              ContentTypes.`application/json`,
+              queryResponse
+            )
+          )
+        )
+    })
+
+  private def givenAnEmptyIndex: TestElasticHttpClient =
+    givenAnIndex("{}")
+
+  private def givenAnIndex(responseHits: Seq[String]): TestElasticHttpClient =
+    givenAnIndex(
+      s"""
+                    {
+                      "hits": {
+                        "hits": [
+                        ${responseHits.mkString(",\n")}
+                        ]  
+                        }
+                    }
+                    """
+    )
+
+  def runFlow(
+    sourceRecords: Seq[CatalogueConcept],
+    client: ElasticHttpClient,
+    expectedCount: Int
+  ): Seq[CatalogueConcept] =
+    Source(sourceRecords)
+      .via(
+        new NotInIndexFlow(
+          elasticHttpClient = client,
+          indexName = indexName
+        ).flow
+      )
+      .runWith(TestSink[CatalogueConcept]())
+      .request(sourceRecords.length)
+      .expectNextN(expectedCount)
+
+  Feature("Filtering Concepts already in the index") {
+    info(
+      """
+     | NotInIndexFlow consumes Concepts and only emits those that have not already been indexed.
+     | It does this by checking for the Concept's canonicalId
+      """.stripMargin
+    )
+
+    Scenario(s"An empty index") {
+      Given("some concepts")
+      val catalogueConcepts = givenSomeConcepts(10)
+
+      And("an index with no data")
+      val client = givenAnEmptyIndex
+
+      When("NotInIndexFlow is run")
+      val results = runFlow(catalogueConcepts, client, 10)
+      Then("all the concepts are returned")
+      results should equal(catalogueConcepts)
+    }
+
+    Scenario(s"All Concepts are already indexed") {
+      Given("some concepts")
+      val catalogueConcepts = givenSomeConcepts(10)
+
+      And("an index with all of them in it")
+      val hits = catalogueConcepts.map(concept =>
+        s"""{"fields": {"canonicalId": ["${concept.canonicalId}"]}}"""
+      )
+
+      val client = givenAnIndex(hits)
+
+      When("NotInIndexFlow is run")
+      val results = runFlow(catalogueConcepts, client, 0)
+      Then("no concepts are returned")
+      results shouldBe Nil
+    }
+
+    Scenario(s"Some Concepts are already indexed") {
+      Given("some concepts")
+      val catalogueConcepts = givenSomeConcepts(10)
+
+      And("an index with some of them in it")
+      val (storedConcepts, newConcepts) = catalogueConcepts.splitAt(5)
+      val hits = storedConcepts.map(concept =>
+        s"""{"fields": {"canonicalId": ["${concept.canonicalId}"]}}"""
+      )
+
+      val client = givenAnIndex(hits)
+
+      When("NotInIndexFlow is run")
+      val results = runFlow(catalogueConcepts, client, 5)
+      Then("only the concepts not in the index are returned")
+      results shouldBe newConcepts
+    }
+
+    Scenario(s"Some Works have multiple Concepts") {
+      Given("some concepts")
+      val catalogueConcepts = givenSomeConcepts(10)
+
+      And("an index with some of them in one Work")
+      val (storedConcepts, newConcepts) = catalogueConcepts.splitAt(5)
+
+      val client = givenAnIndex(Seq(s"""
+        {
+          "fields": {
+            "canonicalId":${storedConcepts
+          .map(_.canonicalId)
+          .mkString("[\"", "\",\"", "\"]")}
+          }
+        }
+      """))
+
+      When("NotInIndexFlow is run")
+      val results = runFlow(catalogueConcepts, client, 5)
+      Then("only the concepts not in the index are returned")
+      results shouldBe newConcepts
+    }
+
+  }
+}

--- a/aggregator/src/test/scala/weco/concepts/aggregator/NotInIndexFlowTest.scala
+++ b/aggregator/src/test/scala/weco/concepts/aggregator/NotInIndexFlowTest.scala
@@ -65,14 +65,14 @@ class NotInIndexFlowTest
   private def givenAnIndex(responseHits: Seq[String]): TestElasticHttpClient =
     givenAnIndex(
       s"""
-                    {
-                      "hits": {
-                        "hits": [
-                        ${responseHits.mkString(",\n")}
-                        ]  
-                        }
-                    }
-                    """
+      {
+        "hits": {
+          "hits": [
+            ${responseHits.mkString(",\n")}
+          ]  
+        }
+      }
+      """
     )
 
   def runFlow(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       - "9002:8080"
     environment:
       - "APP_CONTEXT=docker-compose"
+      - "AWS_LAMBDA_FUNCTION_TIMEOUT=600"
   recorder:
     build:
       context: .


### PR DESCRIPTION
When running a normal bulk update, Elasticsearch is clever enough to very quickly NOOP an update, so all of this is unnecessary.

However, when running an update that attempts to append to an existing record (in a coming PR), it becomes prohibitively slow.  This adds a prior "do I need to send this record to ES?" filter to provide that quick NOOP behaviour.

When running a bulk update locally on an already fully populated index, there is no time difference between running with or without this new flow.  (However, when the magic happens in the next PR, this flow stops the update taking absolutely forever, and instead keeps it down to roughly the same time as a simple upset)