### PR TITLE
buildkite won't parse date unless it's a string

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 env:
-  LIVE_PIPELINE: 2022-08-31
+  LIVE_PIPELINE: "2022-08-31"
 steps:
   - label: "autoformat"
     command: .buildkite/scripts/autoformat.sh


### PR DESCRIPTION
What it says in the commit message
Came to light when opening a PR on content-api