### PR TITLE
Send the Scala dependency graph

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,23 @@
+# .github/workflows/dependency-graph.yml
+name: Update Dependency Graph
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependency-graph:
+    name: Update Dependency Graph
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: eu-west-1
+          role-to-assume: ${{ secrets.WECO_GHAWS_ROLE_ARN }}
+      - uses: scalacenter/sbt-dependency-submission@v2

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,38 @@
+# Automatically mark any pull requests that have been inactive for 30 days as "Stale"
+# then close them 3 days later if there is still no activity.
+# 
+# Shamelessly copied from https://github.com/guardian/.github/blob/main/workflow-templates/stale.yml
+name: "Stale PR Handler"
+
+on:
+  schedule:
+    # Check for Stale PRs every Monday to Thursday morning
+    # Don't check on Fridays as it wouldn't be very nice to have a bot mark your PR as Stale on Friday and then close it on Monday morning!
+    - cron: "0 6 * * MON-THU"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        id: stale
+        # Read about options here: https://github.com/actions/stale#all-options
+        with:
+          # never automatically mark issues as stale
+          days-before-issue-stale: -1
+
+          # Wait 30 days before marking a PR as stale
+          days-before-stale: 30
+          stale-pr-message: >
+            This PR is stale because it has been open 30 days with no activity.
+            Unless a comment is added or the “stale” label removed, this will be closed in 3 days
+
+          # Wait 3 days after a PR has been marked as stale before closing
+          days-before-close: 3
+          close-pr-message: This PR was closed because it has been stalled for 3 days with no activity.
+
+          # Ignore PR's raised by Dependabot
+          exempt-pr-labels: "dependencies"


### PR DESCRIPTION
## What does this change?

Follows https://github.com/wellcomecollection/catalogue-api/pull/766 this change pushes the scala dependency graph to the GitHub API to surface vulnerabilities.

Part of https://github.com/wellcomecollection/platform-infrastructure/issues/431

This change also adds the [stale GitHub workflow](https://github.com/wellcomecollection/catalogue-api/pull/762).

## How to test

- [ ] Does the build go green, can we see the dep graph after merging?

## How can we measure success?

Visibility on dependencies and vulnerabilities. 

## Have we considered potential risks?

This change should help manage / reduce risk.