### PR TITLE
Remove S3 deps setup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,12 +84,3 @@ lazy val recorder = setupProject(
     (ThisBuild / assemblyMergeStrategy).value
   )
 )
-
-// AWS Credentials to read from S3
-s3CredentialsProvider := { _ =>
-  val builder = new STSAssumeRoleSessionCredentialsProvider.Builder(
-    "arn:aws:iam::760097843905:role/platform-ci",
-    UUID.randomUUID().toString
-  )
-  builder.build()
-}

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -9,9 +9,6 @@ object Common {
   val settings: Seq[Def.Setting[_]] = Seq(
     scalaVersion := projectScalaVersion,
     organization := "weco",
-    resolvers ++= Seq(
-      "Wellcome releases" at "s3://releases.mvn-repo.wellcomecollection.org/"
-    ),
     scalacOptions ++= Seq(
       "-deprecation",
       "-unchecked",


### PR DESCRIPTION
## What does this change?

Removes the unused `s3CredentialsProvider` that requires actions here to have permissions that are unnecessary.

## How to test

- [ ] Do the tests pass?

## How can we measure success?

Bit less code!

## Have we considered potential risks?

Should have no risk, the removed code is unused.
