### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # concepts-pipeline
 
+> [!NOTE]
+>  **This repository is now deprecated.** Building on the work of this repository, these services have been replaced by the [catalogue-graph](https://github.com/wellcomecollection/catalogue-pipeline/tree/main/catalogue_graph).
+
+---
+
 _Some sort of ETL pipeline for concepts in the Wellcome Collection catalogue_
 
 Running data through this pipeline results in an index to serve the concepts API with concept data, harvested from an external authority (Initially Library of Congress, then MeSH, and Wikidata, with the possibility of adding other sources as we see fit).


### PR DESCRIPTION
## What does this change?

>[!Note]
> As part of this change, all infrastructure for this project has been `terraform destroy`'ed.

This change adds a deprecation notice, pointing at the catalogue-graph project in the catalogue-pipeline repository. 

The repository should be archived after making this change.

## How to test

- [ ] Does the deprecation notice make sense?

## How can we measure success?

Less code, more clarity about what is in production.

## Have we considered potential risks?

This project is no longer in use and risk should be minimal.
